### PR TITLE
feat: fetch channel videos via RSS feed instead of YouTube Data API

### DIFF
--- a/pages/api/v1/youtube/index.js
+++ b/pages/api/v1/youtube/index.js
@@ -1,0 +1,59 @@
+import { createRouter } from "next-connect";
+import controller from "infra/controller.js";
+
+export default createRouter().get(getHandler).handler(controller.errorHandlers);
+
+// Canal @Judhagsan
+const CHANNEL_ID = "UCVqzru2hZO3pX7IjjkSGDyQ";
+const FEED_URL = `https://www.youtube.com/feeds/videos.xml?channel_id=${CHANNEL_ID}`;
+
+// O card da home lista os vídeos mais recentes do canal. Em vez da YouTube
+// Data API (exige chave — a anterior vivia no bundle do cliente e foi
+// invalidada — e cada search custa 100 das 10.000 unidades/dia de quota),
+// usamos o feed RSS público do canal: sem chave e sem quota. O feed não tem
+// CORS pra browser, então o fetch é server-side; o cache CDN segura o
+// tráfego e mantém a home rápida mesmo se o YouTube demorar.
+async function getHandler(request, response) {
+  const feedResponse = await fetch(FEED_URL);
+  if (!feedResponse.ok) {
+    return response.status(502).json({ error: "YouTube feed request failed" });
+  }
+  const xml = await feedResponse.text();
+
+  const videos = [...xml.matchAll(/<entry>([\s\S]*?)<\/entry>/g)]
+    .slice(0, 3)
+    .map(([, entry]) => {
+      const id = entry.match(/<yt:videoId>([^<]+)<\/yt:videoId>/)?.[1] ?? null;
+      const title = decodeEntities(
+        entry.match(/<title>([^<]*)<\/title>/)?.[1] ?? "",
+      );
+      const publishedAt =
+        entry.match(/<published>([^<]+)<\/published>/)?.[1] ?? null;
+      return {
+        id,
+        title,
+        publishedAt,
+        // Thumbnail por convenção de URL do YouTube (mqdefault = 320x180,
+        // o "medium" que o card usava com a Data API).
+        thumbnail: id ? `https://i.ytimg.com/vi/${id}/mqdefault.jpg` : null,
+      };
+    })
+    .filter((video) => video.id);
+
+  response.setHeader(
+    "Cache-Control",
+    "public, s-maxage=3600, stale-while-revalidate=86400",
+  );
+  return response.status(200).json(videos);
+}
+
+// O feed Atom escapa entidades XML nos títulos. `&amp;` por último — senão
+// um título com "&amp;lt;" literal sofreria decode duplo.
+function decodeEntities(text) {
+  return text
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&#39;", "'")
+    .replaceAll("&amp;", "&");
+}

--- a/pages/components/cardYoutube.js
+++ b/pages/components/cardYoutube.js
@@ -5,27 +5,25 @@ export default function CardYoutube() {
   const [videos, setVideos] = useState([]);
   const [loading, setLoading] = useState(true);
 
-  // API Configuration
-  const API_KEY = "AIzaSyDgmq-MS8a0vzMaDhaM91htD-taz-2lY1A";
   const CHANNEL_ID = "UCVqzru2hZO3pX7IjjkSGDyQ"; // Channel: @Judhagsan
 
   useEffect(() => {
     const fetchVideos = async () => {
       try {
-        const response = await fetch(
-          `https://www.googleapis.com/youtube/v3/search?key=${API_KEY}&channelId=${CHANNEL_ID}&part=snippet,id&order=date&maxResults=3&type=video`,
-        );
+        // Server-side proxy do feed RSS do canal (sem chave de API, sem
+        // quota, com cache CDN) — ver pages/api/v1/youtube.
+        const response = await fetch("/api/v1/youtube");
 
         if (!response.ok) throw new Error("API call failed");
 
         const data = await response.json();
 
-        const formattedVideos = data.items.map((item) => ({
-          id: item.id.videoId,
-          title: item.snippet.title, // NOTE: Titles might have HTML entities
-          thumbnail: item.snippet.thumbnails.medium.url,
-          views: "Watch Now", // Search API doesn't allow fetching views in the same request easily without extra quota
-          date: new Date(item.snippet.publishedAt).toLocaleDateString(),
+        const formattedVideos = data.map((item) => ({
+          id: item.id,
+          title: item.title,
+          thumbnail: item.thumbnail,
+          views: "Assistir",
+          date: new Date(item.publishedAt).toLocaleDateString("pt-BR"),
         }));
 
         setVideos(formattedVideos);
@@ -36,10 +34,10 @@ export default function CardYoutube() {
         setVideos([
           {
             id: 1,
-            title: "API Error or Quota Exceeded - Mock Data",
+            title: "Não foi possível carregar os vídeos",
             thumbnail: "https://img.youtube.com/vi/5qap5aO4i9A/mqdefault.jpg",
-            views: "0 views",
-            date: "Today",
+            views: "—",
+            date: "Hoje",
           },
         ]);
         setLoading(false);
@@ -61,7 +59,7 @@ export default function CardYoutube() {
               <PlayIcon size={16} />
             </div>
             <h2 className="text-xl font-bold tracking-tight text-white">
-              Latest Videos
+              Últimos vídeos
             </h2>
           </div>
           <a
@@ -70,7 +68,7 @@ export default function CardYoutube() {
             rel="noopener noreferrer"
             className="text-xs font-semibold text-white/50 hover:text-white transition-colors uppercase tracking-wider bg-white/5 px-3 py-1 rounded-full cursor-pointer decoration-transparent"
           >
-            View All
+            Ver todos
           </a>
         </div>
 


### PR DESCRIPTION
A chave da Data API vivia no bundle do cliente e foi invalidada — o card caia no fallback. O feed RSS publico do canal nao exige chave nem quota; o fetch e server-side (/api/v1/youtube, o feed nao tem CORS pra browser) com cache CDN de 1h. Textos do card traduzidos pra pt-BR e data em formato brasileiro.