### PR TITLE
feat: novos poderes para usuarios

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -205,11 +205,11 @@ Base URL: `/api/v1`
 
 ### Usuários
 
-| Método  | Endpoint           | Descrição                  |
-| ------- | ------------------ | -------------------------- |
-| `POST`  | `/users`           | Cria um novo usuário       |
-| `GET`   | `/users/:username` | Busca usuário por username |
-| `PATCH` | `/users/:username` | Atualiza dados do usuário  |
+| Método  | Endpoint           | Descrição                                  |
+| ------- | ------------------ | ------------------------------------------ |
+| `POST`  | `/users`           | Cria um novo usuário                       |
+| `GET`   | `/users/:username` | Busca usuário por username                 |
+| `PATCH` | `/users/:username` | Atualiza dados do usuário (exceto a senha) |
 
 ### Sessões
 
@@ -220,10 +220,11 @@ Base URL: `/api/v1`
 
 ### Usuário Autenticado
 
-| Método  | Endpoint          | Descrição                                           |
-| ------- | ----------------- | --------------------------------------------------- |
-| `GET`   | `/user`           | Retorna dados do usuário logado                     |
-| `PATCH` | `/user/supporter` | Define exibição no mural de apoiadores (`apoiador`) |
+| Método  | Endpoint          | Descrição                                             |
+| ------- | ----------------- | ----------------------------------------------------- |
+| `GET`   | `/user`           | Retorna dados do usuário logado                       |
+| `PATCH` | `/user/supporter` | Define exibição no mural de apoiadores (`apoiador`)   |
+| `POST`  | `/user/password`  | Troca a senha do usuário logado (exige a senha atual) |
 
 ### Apoiadores
 
@@ -267,6 +268,31 @@ Base URL: `/api/v1`
 3. Um token de ativação é gerado e enviado por e-mail (expira em 15 minutos)
 4. Usuário clica no link de ativação (`/cadastro/ativar/:tokenId`)
 5. Após ativação, o usuário recebe as features: `create:session`, `read:session`, `update:user`
+
+### Alteração de Senha
+
+Trocar a senha exige confirmar a senha atual e acontece só em
+`POST /api/v1/user/password`. O `PATCH /api/v1/users/:username` rejeita o campo
+`password` com `400`: aceitá-lo ali deixava uma sessão roubada trocar a senha
+sem conhecer a atual, e o spread de `user.update()` gravaria a senha em texto
+puro se a guarda saísse.
+
+1. O usuário logado envia `current_password` e `new_password`
+2. `models/password.compare()` confere a senha atual — se não bate, volta
+   `400 ValidationError` (e não `401`, que faria o `onErrorHandler` limpar o
+   cookie e deslogar quem só errou a digitação)
+3. A nova senha passa pela mesma validação de complexidade do cadastro
+   (8 a 72 caracteres) e precisa ser diferente da atual
+4. Todas as outras sessões do usuário são expiradas
+   (`session.expireAllByUserId`); a sessão atual sobrevive e é renovada
+5. Fica registrado em `audit_logs` como `user.password_changed` — tentativas
+   com senha atual errada viram `user.password_change_failed`
+6. Um email avisa o dono da conta que a senha mudou. Como não existe
+   recuperação por email aqui, esse aviso é o único sinal que chega a quem foi
+   invadido — mas o envio é best-effort: falha de SMTP vira log, não erro na
+   resposta, já que a senha e as sessões nesse ponto já mudaram
+
+O endpoint tem rate limit de 5 tentativas por IP a cada 15 minutos.
 
 ### Features Disponíveis
 

--- a/hooks/useLanguage.js
+++ b/hooks/useLanguage.js
@@ -111,6 +111,16 @@ const translations = {
     "Exportando...": "Exportando...",
     "Erro exportar": "Não foi possível exportar.",
     "Erro excluir conta": "Não foi possível excluir a conta.",
+    "Alterar senha": "Alterar senha",
+    "Texto alterar senha aviso":
+      "Ao trocar a senha, as outras sessões conectadas nesta conta são encerradas. Esta aqui continua ativa.",
+    "Senha atual": "Senha atual",
+    "Nova senha": "Nova senha",
+    "Confirmar nova senha": "Confirmar nova senha",
+    Salvar: "Salvar",
+    "Salvando...": "Salvando...",
+    "Senha alterada": "Senha alterada. As outras sessões foram encerradas.",
+    "Erro alterar senha": "Não foi possível alterar a senha.",
 
     // Session Card
     "Versao para platform em breve": "Versão para {platform} em breve.",
@@ -322,6 +332,16 @@ const translations = {
     "Exportando...": "Exporting...",
     "Erro exportar": "Could not export data.",
     "Erro excluir conta": "Could not delete account.",
+    "Alterar senha": "Change password",
+    "Texto alterar senha aviso":
+      "Changing your password signs out every other session on this account. This one stays active.",
+    "Senha atual": "Current password",
+    "Nova senha": "New password",
+    "Confirmar nova senha": "Confirm new password",
+    Salvar: "Save",
+    "Salvando...": "Saving...",
+    "Senha alterada": "Password changed. Your other sessions were signed out.",
+    "Erro alterar senha": "Could not change the password.",
 
     // Session Card
     "Versao para platform em breve": "Version for {platform} coming soon.",

--- a/models/password.js
+++ b/models/password.js
@@ -1,4 +1,6 @@
 import bcryptjs from "bcryptjs";
+import email from "infra/email.js";
+import webserver from "infra/webserver.js";
 
 async function hash(password) {
   const rounds = getNumberOfRounds();
@@ -13,9 +15,28 @@ async function compare(providedPassword, storedPassword) {
   return await bcryptjs.compare(providedPassword, storedPassword);
 }
 
+async function sendChangedNoticeToUser(user) {
+  await email.send({
+    from: "Judhagsan <contato@judhagsan.com>",
+    to: user.email,
+    subject: "Sua senha em Judhagsan foi alterada",
+    text: `${user.username}, a senha da sua conta em judhagsan.com acabou de ser alterada.
+
+As outras sessões conectadas nesta conta foram encerradas.
+
+Se foi você, não há nada a fazer.
+
+Se não foi você, alguém tem acesso à sua conta e agora sabe a senha. Fale com a gente o quanto antes em ${webserver.origin}/contato.
+
+Atenciosamente,
+Equipe Judhagsan`,
+  });
+}
+
 const password = {
   hash,
   compare,
+  sendChangedNoticeToUser,
 };
 
 export default password;

--- a/models/session.js
+++ b/models/session.js
@@ -110,11 +110,38 @@ async function expireById(sessionId) {
   }
 }
 
+async function expireAllByUserId(userId, { exceptSessionId } = {}) {
+  const expiredSessions = await runUpdateQuery(userId, exceptSessionId);
+  return expiredSessions;
+
+  async function runUpdateQuery(userId, exceptSessionId) {
+    const results = await database.query({
+      text: `
+        UPDATE
+          sessions
+        SET
+          expires_at = expires_at - interval '1 year',
+          updated_at = NOW()
+        WHERE
+          user_id = $1
+          AND expires_at > NOW()
+          AND ($2::uuid IS NULL OR id <> $2::uuid)
+        RETURNING
+          *
+        ;`,
+      values: [userId, exceptSessionId || null],
+    });
+
+    return results.rows;
+  }
+}
+
 const session = {
   create,
   findOneValidByToken,
   renew,
   expireById,
+  expireAllByUserId,
   EXPIRATION_IN_MILLISECONDS,
 };
 

--- a/models/user.js
+++ b/models/user.js
@@ -168,6 +168,16 @@ function validatePasswordComplexity(password) {
 }
 
 async function update(username, userInputValues) {
+  // A senha não passa por aqui: trocá-la exige confirmar a senha atual, o que
+  // é responsabilidade de `updatePasswordById`. Sem esta guarda, um `password`
+  // no corpo seria gravado em texto puro pelo spread abaixo.
+  if ("password" in userInputValues) {
+    throw new ValidationError({
+      message: "A senha não pode ser alterada por este endpoint.",
+      action: "Utilize o endpoint de alteração de senha.",
+    });
+  }
+
   const currentUser = await findOneByUsername(username);
 
   if ("username" in userInputValues) {
@@ -176,11 +186,6 @@ async function update(username, userInputValues) {
 
   if ("email" in userInputValues) {
     await validateUniqueEmail(userInputValues.email);
-  }
-
-  if ("password" in userInputValues) {
-    validatePasswordComplexity(userInputValues.password);
-    await hashPasswordInObject(userInputValues);
   }
 
   const userWithNewValues = { ...currentUser, ...userInputValues };
@@ -210,6 +215,41 @@ async function update(username, userInputValues) {
         userWithNewValues.password,
       ],
     });
+
+    return results.rows[0];
+  }
+}
+
+async function updatePasswordById(userId, newPassword) {
+  validatePasswordComplexity(newPassword);
+
+  const hashedPassword = await password.hash(newPassword);
+  const updatedUser = await runUpdateQuery(userId, hashedPassword);
+
+  return updatedUser;
+
+  async function runUpdateQuery(userId, hashedPassword) {
+    const results = await database.query({
+      text: `
+        UPDATE
+          users
+        SET
+          password = $2,
+          updated_at = timezone('utc', now())
+        WHERE
+          id = $1
+        RETURNING
+          *
+        ;`,
+      values: [userId, hashedPassword],
+    });
+
+    if (results.rowCount === 0) {
+      throw new NotFoundError({
+        message: "O id informado não foi encontrado no sistema.",
+        action: "Verifique se o id está digitado corretamente.",
+      });
+    }
 
     return results.rows[0];
   }
@@ -344,6 +384,7 @@ const user = {
   findOneByUsername,
   findOneByEmail,
   update,
+  updatePasswordById,
   remove,
   setFeatures,
   addFeatures,

--- a/pages/api/v1/user/password/index.js
+++ b/pages/api/v1/user/password/index.js
@@ -1,0 +1,108 @@
+import { createRouter } from "next-connect";
+import controller from "infra/controller.js";
+import user from "models/user.js";
+import password from "models/password.js";
+import session from "models/session.js";
+import auditLog from "models/auditLog.js";
+import { ValidationError } from "infra/errors.js";
+
+export default createRouter()
+  .use(controller.injectAnonymousOrUser)
+  .post(
+    controller.rateLimit({
+      key: "password-change",
+      limit: 5,
+      windowMs: 15 * 60 * 1000,
+    }),
+    controller.canRequest("update:user"),
+    postHandler,
+  )
+  .handler(controller.errorHandlers);
+
+const NO_STORE = "no-store, no-cache, max-age=0, must-revalidate";
+
+async function postHandler(request, response) {
+  const { current_password, new_password } = request.body || {};
+  const ip = controller.getClientIp(request);
+
+  const sessionToken = request.cookies.session_id;
+  const sessionObject = await session.findOneValidByToken(sessionToken);
+  const storedUser = await user.findOneById(sessionObject.user_id);
+
+  if (typeof current_password !== "string" || current_password.length === 0) {
+    throw new ValidationError({
+      message: "É necessário informar a senha atual.",
+      action: "Preencha o campo de senha atual e tente novamente.",
+    });
+  }
+
+  const currentPasswordMatches = await password.compare(
+    current_password,
+    storedUser.password,
+  );
+
+  if (!currentPasswordMatches) {
+    await auditLog.record({
+      action: "user.password_change_failed",
+      actorUserId: storedUser.id,
+      targetUserId: storedUser.id,
+      ip,
+    });
+
+    // ValidationError e não UnauthorizedError de propósito: `onErrorHandler`
+    // limpa o cookie de sessão em 401, e errar a senha atual não pode deslogar
+    // quem está justamente tentando trocá-la.
+    throw new ValidationError({
+      message: "A senha atual não confere.",
+      action: "Verifique a senha atual e tente novamente.",
+    });
+  }
+
+  if (new_password === current_password) {
+    throw new ValidationError({
+      message: "A nova senha deve ser diferente da senha atual.",
+      action: "Escolha uma senha que você ainda não usa nesta conta.",
+    });
+  }
+
+  const updatedUser = await user.updatePasswordById(
+    storedUser.id,
+    new_password,
+  );
+
+  // Trocar a senha derruba as outras sessões: se alguém tinha acesso indevido
+  // à conta, a troca precisa expulsá-lo. A sessão de quem trocou sobrevive e é
+  // renovada, para não obrigar um login logo em seguida.
+  await session.expireAllByUserId(updatedUser.id, {
+    exceptSessionId: sessionObject.id,
+  });
+  const renewedSession = await session.renew(sessionObject.id);
+  controller.setSessionCookie(renewedSession.token, response);
+
+  await auditLog.record({
+    action: "user.password_changed",
+    actorUserId: updatedUser.id,
+    targetUserId: updatedUser.id,
+    ip,
+  });
+
+  // O aviso é o que permite a vítima reagir quando a troca não foi dela — não
+  // existe recuperação por email neste sistema, então é o único sinal que ela
+  // recebe. Mesmo assim não pode derrubar a resposta: a senha já mudou e as
+  // sessões já caíram, e devolver erro faria o usuário achar que nada valeu.
+  try {
+    await password.sendChangedNoticeToUser(updatedUser);
+  } catch (error) {
+    console.error({
+      name: "PasswordChangedNoticeError",
+      underlyingErrorName: error?.name,
+    });
+  }
+
+  response.setHeader("Cache-Control", NO_STORE);
+  return response.status(200).json({
+    id: updatedUser.id,
+    username: updatedUser.username,
+    updated_at: updatedUser.updated_at,
+  });
+}

--- a/pages/components/CardUsuario.js
+++ b/pages/components/CardUsuario.js
@@ -4,6 +4,7 @@ import { useRouter } from "next/router";
 import {
   PersonFillIcon,
   PackageIcon,
+  KeyIcon,
   TrashIcon,
   AlertFillIcon,
   HeartFillIcon,
@@ -35,6 +36,13 @@ export default function CardUsuario({ user }) {
   const [errorMessage, setErrorMessage] = useState("");
   const [isExporting, setIsExporting] = useState(false);
   const [exportError, setExportError] = useState("");
+  const [isChangingPassword, setIsChangingPassword] = useState(false);
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [newPasswordConfirmation, setNewPasswordConfirmation] = useState("");
+  const [isSavingPassword, setIsSavingPassword] = useState(false);
+  const [passwordError, setPasswordError] = useState("");
+  const [passwordChanged, setPasswordChanged] = useState(false);
   const isSupporter = user?.features?.includes("apoiador");
   const discordResult = router.query.discord;
   const discordReason = router.query.reason;
@@ -73,6 +81,59 @@ export default function CardUsuario({ user }) {
       setExportError(t("Erro de conexao"));
     } finally {
       setIsExporting(false);
+    }
+  }
+
+  function resetPasswordForm() {
+    setIsChangingPassword(false);
+    setCurrentPassword("");
+    setNewPassword("");
+    setNewPasswordConfirmation("");
+    setPasswordError("");
+  }
+
+  async function handleChangePassword(event) {
+    event.preventDefault();
+    if (isSavingPassword) return;
+
+    // Validação no cliente só para o que dá para responder na hora; o resto
+    // (senha atual, complexidade) é a API que decide.
+    if (newPassword.length < 8) {
+      setPasswordError(t("A senha deve ter no minimo 8 caracteres"));
+      return;
+    }
+
+    if (newPassword !== newPasswordConfirmation) {
+      setPasswordError(t("As senhas nao conferem"));
+      return;
+    }
+
+    setIsSavingPassword(true);
+    setPasswordError("");
+
+    try {
+      const response = await fetch("/api/v1/user/password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({
+          current_password: currentPassword,
+          new_password: newPassword,
+        }),
+      });
+
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        setPasswordError(body.message || t("Erro alterar senha"));
+        return;
+      }
+
+      resetPasswordForm();
+      setPasswordChanged(true);
+    } catch {
+      setPasswordError(t("Erro de conexao"));
+    } finally {
+      setIsSavingPassword(false);
     }
   }
 
@@ -160,6 +221,86 @@ export default function CardUsuario({ user }) {
               >
                 <TrashIcon size={14} />
                 {isDeleting ? t("Excluindo...") : t("Excluir")}
+              </button>
+            </div>
+          </form>
+        ) : isChangingPassword ? (
+          <form
+            onSubmit={handleChangePassword}
+            className="flex flex-col items-center justify-center text-center gap-4 text-white/70 text-sm relative z-10 flex-1 h-full animate-[fadeIn_0.18s_ease-out]"
+          >
+            <div className="w-14 h-14 rounded-full bg-cyan-500/20 border border-cyan-400/40 flex items-center justify-center text-cyan-200">
+              <KeyIcon size={24} />
+            </div>
+            <p className="text-lg text-white font-semibold">
+              {t("Alterar senha")}
+            </p>
+            <p className="text-xs leading-relaxed max-w-xs">
+              {t("Texto alterar senha aviso")}
+            </p>
+
+            <label className="flex flex-col gap-1 w-full max-w-xs text-left">
+              <span className="text-xs uppercase tracking-widest text-white/50">
+                {t("Senha atual")}
+              </span>
+              <input
+                type="password"
+                value={currentPassword}
+                onChange={(e) => setCurrentPassword(e.target.value)}
+                autoComplete="current-password"
+                className="px-3 py-2 rounded-xl bg-white/5 border border-white/10 focus:border-cyan-400/60 focus:bg-white/10 outline-none text-white placeholder-white/30 transition-colors"
+              />
+            </label>
+
+            <label className="flex flex-col gap-1 w-full max-w-xs text-left">
+              <span className="text-xs uppercase tracking-widest text-white/50">
+                {t("Nova senha")}{" "}
+                <span className="normal-case tracking-normal text-white/30">
+                  ({t("min_char")})
+                </span>
+              </span>
+              <input
+                type="password"
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                autoComplete="new-password"
+                className="px-3 py-2 rounded-xl bg-white/5 border border-white/10 focus:border-cyan-400/60 focus:bg-white/10 outline-none text-white placeholder-white/30 transition-colors"
+              />
+            </label>
+
+            <label className="flex flex-col gap-1 w-full max-w-xs text-left">
+              <span className="text-xs uppercase tracking-widest text-white/50">
+                {t("Confirmar nova senha")}
+              </span>
+              <input
+                type="password"
+                value={newPasswordConfirmation}
+                onChange={(e) => setNewPasswordConfirmation(e.target.value)}
+                autoComplete="new-password"
+                className="px-3 py-2 rounded-xl bg-white/5 border border-white/10 focus:border-cyan-400/60 focus:bg-white/10 outline-none text-white placeholder-white/30 transition-colors"
+              />
+            </label>
+
+            {passwordError && (
+              <p className="text-red-300 text-xs">{passwordError}</p>
+            )}
+
+            <div className="flex gap-3 mt-2">
+              <button
+                type="button"
+                onClick={resetPasswordForm}
+                disabled={isSavingPassword}
+                className="cursor-pointer px-6 py-2 bg-white/5 hover:bg-white/10 border border-white/10 hover:border-white/20 text-white/70 rounded-xl transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed font-semibold text-sm"
+              >
+                {t("Cancelar")}
+              </button>
+              <button
+                type="submit"
+                disabled={isSavingPassword}
+                className="cursor-pointer px-6 py-2 bg-cyan-500/10 hover:bg-cyan-500/30 border border-cyan-500/30 hover:border-cyan-500/60 text-cyan-200 rounded-xl transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed font-semibold text-sm inline-flex items-center gap-2"
+              >
+                <KeyIcon size={14} />
+                {isSavingPassword ? t("Salvando...") : t("Salvar")}
               </button>
             </div>
           </form>
@@ -260,6 +401,18 @@ export default function CardUsuario({ user }) {
 
                 <button
                   type="button"
+                  onClick={() => {
+                    setPasswordChanged(false);
+                    setIsChangingPassword(true);
+                  }}
+                  className="cursor-pointer inline-flex items-center gap-2 text-xs uppercase tracking-widest text-white/40 hover:text-cyan-300 transition-colors"
+                >
+                  <KeyIcon size={12} />
+                  {t("Alterar senha")}
+                </button>
+
+                <button
+                  type="button"
                   onClick={() => setIsConfirming(true)}
                   className="cursor-pointer inline-flex items-center gap-2 text-xs uppercase tracking-widest text-white/40 hover:text-red-300 transition-colors"
                 >
@@ -270,6 +423,12 @@ export default function CardUsuario({ user }) {
 
               {exportError && (
                 <p className="text-red-300 text-xs">{exportError}</p>
+              )}
+
+              {passwordChanged && (
+                <p className="text-emerald-300 text-xs animate-[fadeIn_0.3s_ease-out]">
+                  {t("Senha alterada")}
+                </p>
               )}
             </div>
           </div>

--- a/tests/integration/api/v1/user/password/post.test.js
+++ b/tests/integration/api/v1/user/password/post.test.js
@@ -1,0 +1,268 @@
+import orchestrator from "tests/orchestrator.js";
+import user from "models/user.js";
+import password from "models/password.js";
+import webserver from "infra/webserver.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabase();
+  await orchestrator.runPendingMigrations();
+});
+
+async function createLoggedUser(userObject) {
+  const createdUser = await orchestrator.createUser({
+    password: "senhaAtual123",
+    ...userObject,
+  });
+  const activatedUser = await orchestrator.activateUser(createdUser);
+  const sessionObject = await orchestrator.createSession(activatedUser);
+
+  return { createdUser, sessionObject };
+}
+
+function changePassword({ sessionToken, body }) {
+  return fetch(`${webserver.origin}/api/v1/user/password`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(sessionToken ? { Cookie: `session_id=${sessionToken}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/v1/user/password", () => {
+  describe("Anonymous user", () => {
+    test("Without session", async () => {
+      const response = await changePassword({
+        body: {
+          current_password: "senhaAtual123",
+          new_password: "senhaNova123",
+        },
+      });
+
+      expect(response.status).toBe(403);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "ForbiddenError",
+        message: "Você não possui permissão para executar esta ação.",
+        action: 'Verifique se o seu usuário possui a feature "update:user"',
+        status_code: 403,
+      });
+    });
+  });
+
+  describe("Default user", () => {
+    test("With correct `current_password`", async () => {
+      const { createdUser, sessionObject } = await createLoggedUser();
+
+      const response = await changePassword({
+        sessionToken: sessionObject.token,
+        body: {
+          current_password: "senhaAtual123",
+          new_password: "senhaNova123",
+        },
+      });
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        id: createdUser.id,
+        username: createdUser.username,
+        updated_at: responseBody.updated_at,
+      });
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+
+      const userInDatabase = await user.findOneById(createdUser.id);
+
+      expect(
+        await password.compare("senhaNova123", userInDatabase.password),
+      ).toBe(true);
+      expect(
+        await password.compare("senhaAtual123", userInDatabase.password),
+      ).toBe(false);
+    });
+
+    test("Keeps the current session alive and expires the others", async () => {
+      const { createdUser, sessionObject } = await createLoggedUser();
+      const otherSession = await orchestrator.createSession(createdUser);
+
+      const response = await changePassword({
+        sessionToken: sessionObject.token,
+        body: {
+          current_password: "senhaAtual123",
+          new_password: "senhaNova123",
+        },
+      });
+
+      expect(response.status).toBe(200);
+
+      const currentSessionResponse = await fetch(
+        `${webserver.origin}/api/v1/user`,
+        { headers: { Cookie: `session_id=${sessionObject.token}` } },
+      );
+      expect(currentSessionResponse.status).toBe(200);
+
+      const otherSessionResponse = await fetch(
+        `${webserver.origin}/api/v1/user`,
+        { headers: { Cookie: `session_id=${otherSession.token}` } },
+      );
+      expect(otherSessionResponse.status).toBe(401);
+    });
+
+    test("Sends a notice email to the user", async () => {
+      const { sessionObject } = await createLoggedUser({
+        username: "PasswordChangeNotice",
+        email: "password.change@judhagsan.com",
+      });
+
+      await orchestrator.deleteAllEmails();
+
+      const response = await changePassword({
+        sessionToken: sessionObject.token,
+        body: {
+          current_password: "senhaAtual123",
+          new_password: "senhaNova123",
+        },
+      });
+
+      expect(response.status).toBe(200);
+
+      const lastEmail = await orchestrator.getLastEmail();
+
+      expect(lastEmail.sender).toBe("<contato@judhagsan.com>");
+      expect(lastEmail.recipients[0]).toBe("<password.change@judhagsan.com>");
+      expect(lastEmail.subject).toBe("Sua senha em Judhagsan foi alterada");
+      expect(lastEmail.text).toContain("PasswordChangeNotice");
+      expect(lastEmail.text).toContain(`${webserver.origin}/contato`);
+    });
+
+    test("Does not send an email when the change fails", async () => {
+      const { sessionObject } = await createLoggedUser();
+
+      await orchestrator.deleteAllEmails();
+
+      const response = await changePassword({
+        sessionToken: sessionObject.token,
+        body: {
+          current_password: "senhaErrada123",
+          new_password: "senhaNova123",
+        },
+      });
+
+      expect(response.status).toBe(400);
+      expect(await orchestrator.getLastEmail()).toBeNull();
+    });
+
+    test("With wrong `current_password`", async () => {
+      const { createdUser, sessionObject } = await createLoggedUser();
+
+      const response = await changePassword({
+        sessionToken: sessionObject.token,
+        body: {
+          current_password: "senhaErrada123",
+          new_password: "senhaNova123",
+        },
+      });
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "ValidationError",
+        message: "A senha atual não confere.",
+        action: "Verifique a senha atual e tente novamente.",
+        status_code: 400,
+      });
+
+      // A senha continua a mesma e a sessão não é derrubada: errar a senha
+      // atual não pode deslogar quem está tentando trocá-la.
+      const userInDatabase = await user.findOneById(createdUser.id);
+      expect(
+        await password.compare("senhaAtual123", userInDatabase.password),
+      ).toBe(true);
+
+      const stillLoggedResponse = await fetch(
+        `${webserver.origin}/api/v1/user`,
+        { headers: { Cookie: `session_id=${sessionObject.token}` } },
+      );
+      expect(stillLoggedResponse.status).toBe(200);
+    });
+
+    test("Without `current_password`", async () => {
+      const { sessionObject } = await createLoggedUser();
+
+      const response = await changePassword({
+        sessionToken: sessionObject.token,
+        body: { new_password: "senhaNova123" },
+      });
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "ValidationError",
+        message: "É necessário informar a senha atual.",
+        action: "Preencha o campo de senha atual e tente novamente.",
+        status_code: 400,
+      });
+    });
+
+    test("With `new_password` equal to the current one", async () => {
+      const { sessionObject } = await createLoggedUser();
+
+      const response = await changePassword({
+        sessionToken: sessionObject.token,
+        body: {
+          current_password: "senhaAtual123",
+          new_password: "senhaAtual123",
+        },
+      });
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "ValidationError",
+        message: "A nova senha deve ser diferente da senha atual.",
+        action: "Escolha uma senha que você ainda não usa nesta conta.",
+        status_code: 400,
+      });
+    });
+
+    test("With `new_password` shorter than 8 characters", async () => {
+      const { createdUser, sessionObject } = await createLoggedUser();
+
+      const response = await changePassword({
+        sessionToken: sessionObject.token,
+        body: {
+          current_password: "senhaAtual123",
+          new_password: "curta",
+        },
+      });
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "ValidationError",
+        message: "A senha deve ter no mínimo 8 caracteres.",
+        action: "Escolha uma senha com pelo menos 8 caracteres.",
+        status_code: 400,
+      });
+
+      const userInDatabase = await user.findOneById(createdUser.id);
+      expect(
+        await password.compare("senhaAtual123", userInDatabase.password),
+      ).toBe(true);
+    });
+  });
+});

--- a/tests/integration/api/v1/users/[username]/patch.test.js
+++ b/tests/integration/api/v1/users/[username]/patch.test.js
@@ -270,7 +270,7 @@ describe("PATCH /api/v1/users/[username]", () => {
       expect(userInDatabase.email).toBe("uniqueEmail2@judhagsan.com");
     });
 
-    test("With new `password`", async () => {
+    test("With `password`", async () => {
       const createdUser = await orchestrator.createUser({
         password: "newPassword1",
       });
@@ -291,43 +291,27 @@ describe("PATCH /api/v1/users/[username]", () => {
         },
       );
 
-      expect(response.status).toBe(200);
+      expect(response.status).toBe(400);
 
       const responseBody = await response.json();
 
       expect(responseBody).toEqual({
-        id: responseBody.id,
-        username: createdUser.username,
-        features: [
-          "create:session",
-          "read:session",
-          "update:user",
-          "delete:user",
-          "manage:device",
-        ],
-        created_at: responseBody.created_at,
-        updated_at: responseBody.updated_at,
+        name: "ValidationError",
+        message: "A senha não pode ser alterada por este endpoint.",
+        action: "Utilize o endpoint de alteração de senha.",
+        status_code: 400,
       });
 
-      expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
-      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
-
-      expect(responseBody.updated_at > responseBody.created_at).toBe(true);
-
+      // A senha só muda por POST /api/v1/user/password, que exige a senha
+      // atual. Aceitá-la aqui deixava uma sessão roubada trocar a senha.
       const userInDatabase = await user.findOneByUsername(createdUser.username);
-      const correctPasswordMatch = await password.compare(
-        "newPassword2",
-        userInDatabase.password,
-      );
 
-      const incorrectPasswordMatch = await password.compare(
-        "newPassword1",
-        userInDatabase.password,
-      );
-
-      expect(correctPasswordMatch).toBe(true);
-      expect(incorrectPasswordMatch).toBe(false);
+      expect(
+        await password.compare("newPassword1", userInDatabase.password),
+      ).toBe(true);
+      expect(
+        await password.compare("newPassword2", userInDatabase.password),
+      ).toBe(false);
     });
   });
 


### PR DESCRIPTION
Cria POST /api/v1/user/password: a troca exige a senha atual, derruba as outras sessões do usuário e avisa o dono da conta por email.

O PATCH /api/v1/users/:username passa a rejeitar o campo `password` com 400. Antes ele aceitava a troca sem pedir a senha atual, então uma sessão roubada bastava para tomar a conta. A guarda ficou em user.update(), não só no endpoint: sem ela o spread de userInputValues gravaria a senha em texto puro.

Senha atual errada volta 400, e não 401, porque o onErrorHandler limpa o cookie de sessão em qualquer 401 — deslogaria justamente quem só errou a digitação tentando trocar a senha.

O email de aviso é best-effort: falha de SMTP vira log, não erro na resposta. Nesse ponto a senha e as sessões já mudaram, e devolver erro faria o usuário achar que a troca não valeu.