### PR TITLE
feat: expõe as builds de PR do Pindorama para admin apoiador

### DIFF
--- a/models/pindoramaRelease.js
+++ b/models/pindoramaRelease.js
@@ -1,0 +1,173 @@
+import { ServiceError, NotFoundError } from "infra/errors.js";
+
+const REPO = "judhagsan/pindorama";
+
+// Nome do asset de cada plataforma, igual nos releases estáveis e nos
+// prereleases de PR (os três workflows de build publicam com estes nomes).
+const FILES = {
+  windows: "Pindorama-Setup.exe",
+  macos: "Pindorama-macOS-arm64.dmg",
+  linux: "Pindorama-x86_64.AppImage",
+};
+
+// Builds de PR são publicadas com a tag `pr-<numero>` pelo workflow
+// `prerelease-on-label.yaml` e apagadas pelo `prerelease-cleanup.yaml` quando o
+// PR fecha. Ou seja: a existência do release É a resposta para "tem build de PR
+// disponível agora?" — não precisamos consultar labels nem PRs abertos.
+const PR_TAG_PREFIX = "pr-";
+
+function githubHeaders(accept) {
+  const token = process.env.PINDORAMA_RELEASES_PAT;
+  if (!token) {
+    throw new ServiceError({
+      message: "Token de acesso aos releases do Pindorama não configurado.",
+      action: "Defina PINDORAMA_RELEASES_PAT no ambiente.",
+    });
+  }
+  return {
+    Authorization: `Bearer ${token}`,
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "judhagsan-prerelease-proxy",
+    Accept: accept,
+  };
+}
+
+// A build de PR mais recente, ou `null` quando nenhum PR tem a label `build`
+// no momento.
+//
+// `releases?per_page=30` em vez de `releases/latest`: o endpoint `latest`
+// ignora prereleases por definição. A ordenação da API é por data de criação
+// (mais recente primeiro), mas desempatamos por `published_at` porque um
+// release pode ser criado e publicado em momentos diferentes.
+async function findLatestPrerelease() {
+  const response = await fetch(
+    `https://api.github.com/repos/${REPO}/releases?per_page=30`,
+    { headers: githubHeaders("application/vnd.github+json") },
+  );
+
+  if (!response.ok) {
+    throw new ServiceError({
+      message: `GitHub respondeu ${response.status} ao listar releases.`,
+      action: "Tente novamente em alguns instantes.",
+    });
+  }
+
+  return selectLatestPrerelease(await response.json());
+}
+
+// Regra PURA de seleção, separada da chamada de rede para ser testável: entre
+// todos os releases do repositório, qual é a build de PR mais recente.
+//
+// Três filtros, cada um por um motivo próprio: `prerelease` exclui os releases
+// estáveis; o prefixo `pr-` exclui prereleases que não vieram de PR (uma beta
+// manual, por exemplo); e `draft` exclui o que ainda não tem asset publicado —
+// esse apareceria como build disponível e falharia no download.
+function selectLatestPrerelease(releases) {
+  const candidates = (Array.isArray(releases) ? releases : [])
+    .filter((release) => release.prerelease === true)
+    .filter((release) =>
+      String(release.tag_name || "").startsWith(PR_TAG_PREFIX),
+    )
+    .filter((release) => release.draft !== true);
+
+  if (candidates.length === 0) return null;
+
+  // A API já devolve por data de criação, mas um release pode ser criado e
+  // publicado em momentos diferentes — o que vale para "a build mais recente"
+  // é quando ela ficou publicada.
+  candidates.sort((a, b) => {
+    const da = Date.parse(a.published_at || a.created_at || 0);
+    const db = Date.parse(b.published_at || b.created_at || 0);
+    return db - da;
+  });
+
+  return candidates[0];
+}
+
+// Número do PR a partir da tag `pr-<numero>`. `null` quando a tag não segue o
+// formato — não é erro, só não temos o número para exibir.
+function prNumberFromTag(tag) {
+  const match = String(tag || "").match(/^pr-(\d+)$/);
+  return match ? Number(match[1]) : null;
+}
+
+// Resumo que o Pindorama consome para decidir se mostra o botão de build de
+// teste. Sem versão semântica na resposta de propósito: build de PR não é
+// "versão maior", é uma build sob demanda — quem instala está testando aquele
+// PR, não atualizando.
+async function prereleaseSummary() {
+  const release = await findLatestPrerelease();
+  if (!release) return { available: false };
+
+  return {
+    available: true,
+    tag: release.tag_name,
+    pr_number: prNumberFromTag(release.tag_name),
+    name: release.name || null,
+    published_at: release.published_at || release.created_at || null,
+    // Quais plataformas de fato têm instalador nesse prerelease: um dos três
+    // jobs de build pode ter falhado, e aí o botão não deve prometer download
+    // para aquela plataforma.
+    platforms: Object.keys(FILES).filter((platform) =>
+      (release.assets || []).some((asset) => asset.name === FILES[platform]),
+    ),
+  };
+}
+
+// URL assinada (efêmera) do asset da plataforma no prerelease mais recente.
+// Lança NotFoundError quando não há build de PR ou quando aquele job não
+// publicou o instalador daquela plataforma.
+async function prereleaseDownloadUrl(platform) {
+  const filename = FILES[platform];
+  if (!filename) {
+    throw new NotFoundError({
+      message: "Plataforma não suportada.",
+      action: "Use windows, macos ou linux.",
+    });
+  }
+
+  const release = await findLatestPrerelease();
+  if (!release) {
+    throw new NotFoundError({
+      message: "Nenhuma build de PR disponível no momento.",
+      action: "Adicione a label build a um PR aberto do Pindorama.",
+    });
+  }
+
+  const asset = (release.assets || []).find((item) => item.name === filename);
+  if (!asset) {
+    throw new NotFoundError({
+      message: `A build ${release.tag_name} não tem o instalador de ${platform}.`,
+      action: "Verifique se o job daquela plataforma concluiu no workflow.",
+    });
+  }
+
+  const assetResponse = await fetch(
+    `https://api.github.com/repos/${REPO}/releases/assets/${asset.id}`,
+    {
+      headers: githubHeaders("application/octet-stream"),
+      redirect: "manual",
+    },
+  );
+
+  const signedUrl = assetResponse.headers.get("location");
+  if (!signedUrl) {
+    throw new ServiceError({
+      message: "Falha ao obter a URL assinada do asset.",
+      action: "Tente novamente em alguns instantes.",
+    });
+  }
+
+  return signedUrl;
+}
+
+const pindoramaRelease = {
+  FILES,
+  findLatestPrerelease,
+  selectLatestPrerelease,
+  prNumberFromTag,
+  prereleaseSummary,
+  prereleaseDownloadUrl,
+};
+
+export default pindoramaRelease;

--- a/pages/api/v1/prerelease/download/[platform].js
+++ b/pages/api/v1/prerelease/download/[platform].js
@@ -1,0 +1,29 @@
+import { createRouter } from "next-connect";
+import controller from "infra/controller.js";
+import pindoramaRelease from "models/pindoramaRelease.js";
+
+// Download do instalador da build de PR mais recente. Espelha
+// `/api/v1/download/[platform]` (release estável), com duas diferenças:
+//
+// 1. Exige `admin` E `apoiador` — o release estável é público, este não.
+// 2. Resolve o asset no prerelease `pr-*` mais recente em vez do
+//    `releases/latest`, que por definição ignora prereleases.
+//
+// O redirect leva a uma URL assinada e efêmera do GitHub: o repositório é
+// privado e o token nunca chega ao cliente.
+export default createRouter()
+  .use(controller.injectAnonymousOrUser)
+  .get(
+    controller.canRequest("admin"),
+    controller.canRequest("apoiador"),
+    getHandler,
+  )
+  .handler(controller.errorHandlers);
+
+async function getHandler(request, response) {
+  const platform = String(request.query.platform || "").toLowerCase();
+  const signedUrl = await pindoramaRelease.prereleaseDownloadUrl(platform);
+
+  response.setHeader("Cache-Control", "no-store");
+  return response.redirect(302, signedUrl);
+}

--- a/pages/api/v1/prerelease/index.js
+++ b/pages/api/v1/prerelease/index.js
@@ -1,0 +1,33 @@
+import { createRouter } from "next-connect";
+import controller from "infra/controller.js";
+import pindoramaRelease from "models/pindoramaRelease.js";
+
+// Builds de PR do Pindorama: o instalador que sai do workflow disparado pela
+// label `build` num PR aberto.
+//
+// Existe para quem TESTA o app antes do release — não é um canal de
+// atualização. Por isso a resposta não traz versão semântica: uma build de PR
+// pode ter a mesma versão do release instalado, ou até uma menor, e mesmo
+// assim ser a que a pessoa quer instalar naquele momento.
+//
+// Duas features exigidas, encadeadas: `admin` (é build interna, sem
+// compromisso de estabilidade) E `apoiador` (o acesso antecipado é parte do
+// que se recebe por apoiar). Ter só uma das duas não basta — são perguntas
+// diferentes, e o `canRequest` de cada uma responde a sua.
+export default createRouter()
+  .use(controller.injectAnonymousOrUser)
+  .get(
+    controller.canRequest("admin"),
+    controller.canRequest("apoiador"),
+    getHandler,
+  )
+  .handler(controller.errorHandlers);
+
+async function getHandler(request, response) {
+  const summary = await pindoramaRelease.prereleaseSummary();
+
+  // Sem cache: o prerelease aparece e some conforme a label entra e o PR
+  // fecha, e o botão no app precisa refletir isso na próxima checagem.
+  response.setHeader("Cache-Control", "no-store");
+  return response.status(200).json(summary);
+}

--- a/tests/integration/api/v1/prerelease/prerelease.test.js
+++ b/tests/integration/api/v1/prerelease/prerelease.test.js
@@ -1,0 +1,141 @@
+import orchestrator from "tests/orchestrator.js";
+import webserver from "infra/webserver.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabase();
+  await orchestrator.runPendingMigrations();
+});
+
+async function authenticatedFetch(path, sessionToken) {
+  return fetch(`${webserver.origin}${path}`, {
+    redirect: "manual",
+    headers: { Cookie: `session_id=${sessionToken}` },
+  });
+}
+
+// Cria um usuário ativado com as features pedidas e devolve o token de sessão.
+async function sessionWithFeatures(username, features) {
+  const userObject = await orchestrator.createUser({ username });
+  await orchestrator.activateUser(userObject);
+  if (features.length > 0) {
+    await orchestrator.addFeaturesToUser(userObject, features);
+  }
+  const session = await orchestrator.createSession(userObject);
+  return session.token;
+}
+
+// O acesso é o que estes testes verificam. O CONTEÚDO da resposta depende do
+// GitHub (existe build de PR agora?) e do PINDORAMA_RELEASES_PAT, que não está
+// no ambiente de teste — então o caso autorizado afirma apenas que NÃO é 403:
+// passou pela autorização e seguiu para o proxy. Um 403 aqui significaria que
+// a regra de features quebrou, que é o que não pode acontecer em silêncio.
+function expectNotForbidden(status) {
+  expect(status).not.toBe(403);
+}
+
+describe("GET /api/v1/prerelease", () => {
+  test("Anônimo não acessa", async () => {
+    const response = await fetch(`${webserver.origin}/api/v1/prerelease`);
+    expect(response.status).toBe(403);
+  });
+
+  test("Usuário comum não acessa", async () => {
+    const token = await sessionWithFeatures("prerelease_comum", []);
+    const response = await authenticatedFetch("/api/v1/prerelease", token);
+    expect(response.status).toBe(403);
+  });
+
+  test("Só admin não basta", async () => {
+    // As duas features são exigidas juntas: build interna (admin) que é
+    // benefício de quem apoia (apoiador).
+    const token = await sessionWithFeatures("prerelease_so_admin", ["admin"]);
+    const response = await authenticatedFetch("/api/v1/prerelease", token);
+    expect(response.status).toBe(403);
+  });
+
+  test("Só apoiador não basta", async () => {
+    const token = await sessionWithFeatures("prerelease_so_apoiador", [
+      "apoiador",
+    ]);
+    const response = await authenticatedFetch("/api/v1/prerelease", token);
+    expect(response.status).toBe(403);
+  });
+
+  test("Admin + apoiador passa pela autorização", async () => {
+    const token = await sessionWithFeatures("prerelease_admin_apoiador", [
+      "admin",
+      "apoiador",
+    ]);
+    const response = await authenticatedFetch("/api/v1/prerelease", token);
+    expectNotForbidden(response.status);
+  });
+
+  test("Não aceita POST", async () => {
+    const token = await sessionWithFeatures("prerelease_post", [
+      "admin",
+      "apoiador",
+    ]);
+    const response = await fetch(`${webserver.origin}/api/v1/prerelease`, {
+      method: "POST",
+      headers: { Cookie: `session_id=${token}` },
+    });
+    expect(response.status).toBe(405);
+  });
+});
+
+describe("GET /api/v1/prerelease/download/[platform]", () => {
+  test("Anônimo não baixa", async () => {
+    const response = await fetch(
+      `${webserver.origin}/api/v1/prerelease/download/windows`,
+      { redirect: "manual" },
+    );
+    expect(response.status).toBe(403);
+  });
+
+  test("Usuário comum não baixa", async () => {
+    const token = await sessionWithFeatures("prerelease_dl_comum", []);
+    const response = await authenticatedFetch(
+      "/api/v1/prerelease/download/windows",
+      token,
+    );
+    expect(response.status).toBe(403);
+  });
+
+  test("Só apoiador não baixa", async () => {
+    const token = await sessionWithFeatures("prerelease_dl_apoiador", [
+      "apoiador",
+    ]);
+    const response = await authenticatedFetch(
+      "/api/v1/prerelease/download/macos",
+      token,
+    );
+    expect(response.status).toBe(403);
+  });
+
+  test("Admin + apoiador passa pela autorização", async () => {
+    const token = await sessionWithFeatures("prerelease_dl_ok", [
+      "admin",
+      "apoiador",
+    ]);
+    const response = await authenticatedFetch(
+      "/api/v1/prerelease/download/linux",
+      token,
+    );
+    expectNotForbidden(response.status);
+  });
+
+  test("Plataforma inválida é rejeitada antes de consultar o GitHub", async () => {
+    // 404 (e não 403): a autorização passou e o erro é do parâmetro. Também
+    // garante que a lista de plataformas não virou aberta.
+    const token = await sessionWithFeatures("prerelease_dl_plataforma", [
+      "admin",
+      "apoiador",
+    ]);
+    const response = await authenticatedFetch(
+      "/api/v1/prerelease/download/atari",
+      token,
+    );
+    expect(response.status).toBe(404);
+  });
+});

--- a/tests/unit/models/pindoramaRelease.test.js
+++ b/tests/unit/models/pindoramaRelease.test.js
@@ -1,0 +1,127 @@
+import pindoramaRelease from "models/pindoramaRelease.js";
+
+// A seleção da build de PR é a regra que decide se o botão "build de teste"
+// aparece no Pindorama e qual build ele instala. Errar aqui tem duas caras
+// ruins: prometer uma build que não existe mais (o release é apagado quando o
+// PR fecha) ou oferecer uma antiga quando há uma mais nova.
+
+function release(overrides = {}) {
+  return {
+    tag_name: "pr-1",
+    prerelease: true,
+    draft: false,
+    published_at: "2026-08-01T00:00:00Z",
+    assets: [],
+    ...overrides,
+  };
+}
+
+describe("selectLatestPrerelease", () => {
+  test("sem releases devolve null", () => {
+    expect(pindoramaRelease.selectLatestPrerelease([])).toBeNull();
+    expect(pindoramaRelease.selectLatestPrerelease(null)).toBeNull();
+    expect(pindoramaRelease.selectLatestPrerelease(undefined)).toBeNull();
+  });
+
+  test("ignora releases estáveis", () => {
+    // O canal de build de PR nunca deve oferecer o release público: quem quer
+    // esse já tem o botão de update normal.
+    const releases = [
+      release({ tag_name: "v0.5.6", prerelease: false }),
+      release({ tag_name: "v0.5.5", prerelease: false }),
+    ];
+    expect(pindoramaRelease.selectLatestPrerelease(releases)).toBeNull();
+  });
+
+  test("ignora prerelease que não veio de PR", () => {
+    // Uma beta publicada à mão (tag `v0.6.0-beta1`) é prerelease, mas não é
+    // build de PR — e o download resolveria o asset errado.
+    const releases = [release({ tag_name: "v0.6.0-beta1" })];
+    expect(pindoramaRelease.selectLatestPrerelease(releases)).toBeNull();
+  });
+
+  test("ignora rascunho", () => {
+    // Draft não tem asset publicado: apareceria como build disponível e o
+    // download falharia na cara de quem clicou.
+    const releases = [release({ tag_name: "pr-42", draft: true })];
+    expect(pindoramaRelease.selectLatestPrerelease(releases)).toBeNull();
+  });
+
+  test("escolhe a build publicada mais recente", () => {
+    const releases = [
+      release({ tag_name: "pr-10", published_at: "2026-08-01T10:00:00Z" }),
+      release({ tag_name: "pr-42", published_at: "2026-08-20T10:00:00Z" }),
+      release({ tag_name: "pr-7", published_at: "2026-07-01T10:00:00Z" }),
+    ];
+    expect(pindoramaRelease.selectLatestPrerelease(releases).tag_name).toBe(
+      "pr-42",
+    );
+  });
+
+  test("ordena por publicação, não pela ordem da resposta", () => {
+    // A API devolve por data de CRIAÇÃO; um release criado antes pode ter sido
+    // publicado depois (build refeita num push novo com a label já presente).
+    const releases = [
+      release({
+        tag_name: "pr-10",
+        created_at: "2026-08-25T00:00:00Z",
+        published_at: "2026-08-01T00:00:00Z",
+      }),
+      release({
+        tag_name: "pr-11",
+        created_at: "2026-08-02T00:00:00Z",
+        published_at: "2026-08-26T00:00:00Z",
+      }),
+    ];
+    expect(pindoramaRelease.selectLatestPrerelease(releases).tag_name).toBe(
+      "pr-11",
+    );
+  });
+
+  test("cai para created_at quando não há published_at", () => {
+    const releases = [
+      release({
+        tag_name: "pr-1",
+        published_at: null,
+        created_at: "2026-08-01T00:00:00Z",
+      }),
+      release({
+        tag_name: "pr-2",
+        published_at: null,
+        created_at: "2026-08-20T00:00:00Z",
+      }),
+    ];
+    expect(pindoramaRelease.selectLatestPrerelease(releases).tag_name).toBe(
+      "pr-2",
+    );
+  });
+});
+
+describe("prNumberFromTag", () => {
+  test("extrai o número do PR", () => {
+    expect(pindoramaRelease.prNumberFromTag("pr-42")).toBe(42);
+    expect(pindoramaRelease.prNumberFromTag("pr-1")).toBe(1);
+  });
+
+  test("devolve null para tag fora do formato", () => {
+    // Não é erro: só não temos número para exibir no botão.
+    expect(pindoramaRelease.prNumberFromTag("v0.5.6")).toBeNull();
+    expect(pindoramaRelease.prNumberFromTag("pr-")).toBeNull();
+    expect(pindoramaRelease.prNumberFromTag("pr-abc")).toBeNull();
+    expect(pindoramaRelease.prNumberFromTag(null)).toBeNull();
+    expect(pindoramaRelease.prNumberFromTag(undefined)).toBeNull();
+  });
+});
+
+describe("FILES", () => {
+  test("cobre as três plataformas com os nomes que os workflows publicam", () => {
+    // Se um workflow mudar o nome do artefato e este mapa não acompanhar, o
+    // download devolve 404 só naquela plataforma — o tipo de quebra que passa
+    // despercebida até alguém tentar baixar.
+    expect(pindoramaRelease.FILES).toEqual({
+      windows: "Pindorama-Setup.exe",
+      macos: "Pindorama-macOS-arm64.dmg",
+      linux: "Pindorama-x86_64.AppImage",
+    });
+  });
+});


### PR DESCRIPTION
O app só tinha o canal público de atualização. Quem testa o Pindorama antes do release precisava baixar o instalador na mão, do prerelease do PR no GitHub — que fica num repositório privado.

Duas rotas novas resolvem isso pelo mesmo proxy que já serve o release: uma diz qual é a build de PR mais recente e a outra devolve o instalador dela. O `prerelease-on-label.yaml` publica a tag `pr-<numero>` quando a label `build` entra e o `prerelease-cleanup.yaml` a apaga quando o PR fecha, então a existência do release já É a resposta para "tem build disponível agora?" — sem consultar labels nem PRs abertos.

Acesso exige `admin` E `apoiador`, encadeadas: é build interna, sem compromisso de estabilidade, e o acesso antecipado é parte do que se recebe por apoiar. Ter só uma das duas não basta.

A resposta não traz versão semântica de propósito: uma build de PR costuma ter a mesma versão do release instalado, e mesmo assim é a que se quer instalar. E traz `platforms`, as plataformas que de fato têm instalador naquele prerelease — se o job do Windows falhou, o app não promete um download que daria 404.